### PR TITLE
refactor cost table

### DIFF
--- a/src/components/FixedCostsComponents/FixedCostTable.vue
+++ b/src/components/FixedCostsComponents/FixedCostTable.vue
@@ -44,6 +44,7 @@ onUpdated(() => {
         :key="fixedCost.id"
       >
         <cost-row
+          @click="openEditFormModal(fixedCost.id, 'fixed')"
           parentClass="flex flex-row w-full items-end"
           cellClass1="basis-6/24 pr-2 md:pr-6"
           cellClass2="basis-3/24 pr-2 md:pr-6"
@@ -54,7 +55,9 @@ onUpdated(() => {
           :amount="fixedCost.amount"
           :frequency="fixedCost.frequency"
           :individual-total="fixedCost.individualTotal"
-        />
+        >
+      
+        </cost-row>
         <form-button
           class="md:flex md:flex-row hidden basis-3/24 h-full pt-6"
           btnImage="/src/images/delete-cost.svg"

--- a/src/components/FixedCostsComponents/FixedCostTable.vue
+++ b/src/components/FixedCostsComponents/FixedCostTable.vue
@@ -30,22 +30,17 @@ onUpdated(() => {
         <p>{{ heading[0] }}</p>
       </div>
     </div>
-    <options-menu
-      v-if="optionsMenuIsOpen"
-      @edit-event="openEditFormModal(selectedId, 'fixed')"
-      @delete-event="openConfirmModal(selectedId, 'fixed')"
-      @menu-event="closeOptionsMenu()"
-    />
+
     <div class="max-h-32 sm:max-h-64 w-screen sm:w-full overflow-auto">
       <div
-        class="h-10 md:h-16 flex flex-row w-full"
+        class="relative h-10 md:h-16 flex flex-row w-full"
         v-for="fixedCost in fixedCosts"
         :id="fixedCost.id"
         :key="fixedCost.id"
       >
         <fixed-cost-row
           @click="openEditFormModal(fixedCost.id, 'fixed')"
-          parentClass="flex flex-row w-full items-end"
+          parentClass=" flex flex-row w-full items-end"
           cellClass1="basis-6/24 pr-2 md:pr-6"
           cellClass2="basis-3/24 pr-2 md:pr-6"
           pClass="border-b border-grey-200"
@@ -56,8 +51,14 @@ onUpdated(() => {
           :frequency="fixedCost.frequency"
           :individual-total="fixedCost.individualTotal"
         >
-      
+          
         </fixed-cost-row>
+        <options-menu
+            v-if="optionsMenuIsOpen && selectedId === fixedCost.id"
+            @edit-event="openEditFormModal(selectedId, 'fixed')"
+            @delete-event="openConfirmModal(selectedId, 'fixed')"
+            @menu-event="closeOptionsMenu()"
+          />
         <form-button
           class="md:flex md:flex-row hidden basis-3/24 h-full pt-6"
           btnImage="/src/images/delete-cost.svg"

--- a/src/components/FixedCostsComponents/FixedCostTable.vue
+++ b/src/components/FixedCostsComponents/FixedCostTable.vue
@@ -8,7 +8,7 @@ import scrollToNewCost from '../../assets/utility_functions/scrollToNewCost'
 import FixedCostDataInput from './FixedCostDataInput.vue'
 import OptionsMenu from '../ModalComponents/OptionsMenu.vue'
 import { useModalStore } from '../../stores/modalStore'
-import CostRow from '../FormComponents/CostRow.vue'
+import FixedCostRow from '../FormComponents/FixedCostRow.vue'
 
 const modalStore = useModalStore()
 const { optionsMenuIsOpen } = storeToRefs(modalStore)
@@ -43,7 +43,7 @@ onUpdated(() => {
         :id="fixedCost.id"
         :key="fixedCost.id"
       >
-        <cost-row
+        <fixed-cost-row
           @click="openEditFormModal(fixedCost.id, 'fixed')"
           parentClass="flex flex-row w-full items-end"
           cellClass1="basis-6/24 pr-2 md:pr-6"
@@ -57,7 +57,7 @@ onUpdated(() => {
           :individual-total="fixedCost.individualTotal"
         >
       
-        </cost-row>
+        </fixed-cost-row>
         <form-button
           class="md:flex md:flex-row hidden basis-3/24 h-full pt-6"
           btnImage="/src/images/delete-cost.svg"

--- a/src/components/FixedCostsComponents/FixedCostTable.vue
+++ b/src/components/FixedCostsComponents/FixedCostTable.vue
@@ -50,9 +50,7 @@ onUpdated(() => {
           :amount="fixedCost.amount"
           :frequency="fixedCost.frequency"
           :individual-total="fixedCost.individualTotal"
-        >
-          
-        </fixed-cost-row>
+        />
         <options-menu
             v-if="optionsMenuIsOpen && selectedId === fixedCost.id"
             @edit-event="openEditFormModal(selectedId, 'fixed')"

--- a/src/components/FormComponents/CostRow.vue
+++ b/src/components/FormComponents/CostRow.vue
@@ -52,7 +52,7 @@ defineProps({
 })
 </script>
 <template>
-  <div :class=parentClass  @click="" :name=id>
+  <div :class=parentClass :name=id>
     <div :class=cellClass1>
         <p :class=pClass> {{ costName }}</p>
     </div>
@@ -68,6 +68,5 @@ defineProps({
     <div :class=cellClass2>
         <p :class=pClass> {{ individualTotal }}</p>
     </div>
-    
   </div>
 </template>

--- a/src/components/FormComponents/FixedCostRow.vue
+++ b/src/components/FormComponents/FixedCostRow.vue
@@ -5,10 +5,6 @@ const modalStore = useModalStore()
 const { openEditFormModal } = modalStore
 
 defineProps({
-  costArr: {
-    type: String,
-    default: ''
-  },
   parentClass: {
     type: String,
     default: ''

--- a/src/components/FormComponents/VariableCostRow.vue
+++ b/src/components/FormComponents/VariableCostRow.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { useModalStore } from '../../stores/modalStore'
+
+const modalStore = useModalStore()
+const { openEditFormModal } = modalStore
+
+defineProps({
+  parentClass: {
+    type: String,
+    default: ''
+  },
+  cellClass: {
+    type: String,
+    default: ''
+  },
+  pClass: {
+    type: String,
+    default: ''
+  },
+  id: {
+    type: String,
+    default: ''
+  },
+  costName: {
+    type: String,
+    default: ''
+  },
+  category: {
+    type: String,
+    default: ''
+  },
+  amount: {
+    type: Number,
+    default: 0
+  },
+  frequency: {
+    type: String,
+    default: ''
+  },
+  individualTotal: {
+    type: Number,
+    default: 0
+  },
+})
+</script>
+<template>
+  <div :class=parentClass :name=id>
+    <div :class=cellClass>
+        <p :class=pClass> {{ costName }}</p>
+    </div>
+    <div :class=cellClass>
+        <p :class=pClass> {{ category }}</p>
+    </div>
+    <div :class=cellClass>
+        <p :class=pClass> {{ amount }}</p>
+    </div>
+  </div>
+</template>

--- a/src/components/ModalComponents/OptionsMenu.vue
+++ b/src/components/ModalComponents/OptionsMenu.vue
@@ -24,10 +24,10 @@ defineEmits(['menu-event', 'edit-event', 'delete-event'])
 
 <template>
   <div
-    class="absolute top-0 bottom-0 left-0 right-0 z-10 h-full w-full"
+    class="fixed top-0 bottom-0 left-0 right-0 z-10 h-full w-full"
     @click="$emit('menu-event')"
   ></div>
-  <div class="absolute  top-0 right-0 options-menu h-[85px] w-[85px] z-20" 
+  <div class="absolute top-0 right-0 options-menu h-[85px] w-[85px] z-20" 
   
   >
     <section

--- a/src/components/ModalComponents/OptionsMenu.vue
+++ b/src/components/ModalComponents/OptionsMenu.vue
@@ -1,25 +1,6 @@
 <script setup lang="ts">
-import { onUpdated } from 'vue';
 import FormButton from '../FormComponents/FormButton.vue'
-
 defineEmits(['menu-event', 'edit-event', 'delete-event'])
-
-// const props = defineProps({
-//   xLoc: {
-//     type: String,
-//     default: ''
-   
-//   },
-//   yLoc: {
-//     type: String,
-//     default: ''
-   
-//   }
-//   })
-
-// onUpdated(()=>{
-//   console.log("hello",props.xLoc)
-// })  :style="{left:props.xLoc + 'px', top:props.yLoc + 'px'}"
 </script>
 
 <template>
@@ -27,9 +8,7 @@ defineEmits(['menu-event', 'edit-event', 'delete-event'])
     class="fixed top-0 bottom-0 left-0 right-0 z-10 h-full w-full"
     @click="$emit('menu-event')"
   ></div>
-  <div class="absolute top-0 right-0 options-menu h-[85px] w-[85px] z-20" 
-  
-  >
+  <div class="absolute top-0 right-0 options-menu h-[85px] w-[85px] z-20">
     <section
       class="bg-primary-white flex flex-col justify-center items-center max-w-[100px] max-h-[100px]"
     >

--- a/src/components/ModalComponents/OptionsMenu.vue
+++ b/src/components/ModalComponents/OptionsMenu.vue
@@ -24,10 +24,10 @@ defineEmits(['menu-event', 'edit-event', 'delete-event'])
 
 <template>
   <div
-    class="fixed top-0 bottom-0 left-0 right-0 z-10 h-full w-full"
+    class="absolute top-0 bottom-0 left-0 right-0 z-10 h-full w-full"
     @click="$emit('menu-event')"
   ></div>
-  <div class="options-menu absolute options-menu h-[85px] w-[85px] z-20" 
+  <div class="absolute  top-0 right-0 options-menu h-[85px] w-[85px] z-20" 
   
   >
     <section

--- a/src/components/VariableCostsComponents/VariableCostTable.vue
+++ b/src/components/VariableCostsComponents/VariableCostTable.vue
@@ -12,13 +12,8 @@ import VariableCostRow from '../FormComponents/VariableCostRow.vue'
 
 const modalStore = useModalStore()
 const { optionsMenuIsOpen } = storeToRefs(modalStore)
-const {
-  openOptionsMenu,
-  openFormModal,
-  openEditFormModal,
-  openConfirmModal,
-  closeOptionsMenu,
-} = modalStore
+const { openOptionsMenu, openFormModal, openEditFormModal, openConfirmModal, closeOptionsMenu } =
+  modalStore
 
 const reportStore = useReportStore()
 const { variableCosts, selectedId } = storeToRefs(reportStore)
@@ -35,21 +30,15 @@ onUpdated(() => {
         <p>{{ heading[0] }}</p>
       </div>
     </div>
-    <options-menu
-      v-if="optionsMenuIsOpen"
-      @edit-event="openEditFormModal(selectedId, 'variable')"
-      @delete-event="openConfirmModal(selectedId, 'variable')"
-      @menu-event="closeOptionsMenu()"
-    />
 
     <div class="max-h-32 md:max-h-64 w-screen sm:w-full overflow-auto">
       <div
-        class="h-10 md:h-16 flex flex-row w-full"
+        class="relative h-10 md:h-16 flex flex-row w-full"
         v-for="variableCost in variableCosts"
         :id="variableCost.id"
         :key="variableCost.id"
       >
-      <variable-cost-row
+        <variable-cost-row
           @click="openEditFormModal(variableCost.id, 'variable')"
           parentClass="flex flex-row w-full items-end"
           cellClass="basis-6/18 pr-2 md:pr-6"
@@ -58,9 +47,13 @@ onUpdated(() => {
           :costName="variableCost.name"
           :category="variableCost.category"
           :amount="variableCost.amount"
-        >
-      
-        </variable-cost-row>
+        />
+        <options-menu
+          v-if="optionsMenuIsOpen  && selectedId === variableCost.id"
+          @edit-event="openEditFormModal(selectedId, 'variable')"
+          @delete-event="openConfirmModal(selectedId, 'variable')"
+          @menu-event="closeOptionsMenu()"
+        />
         <form-button
           class="md:flex md:flex-row hidden basis-3/24 h-full pt-6"
           btnImage="/src/images/delete-cost.svg"

--- a/src/components/VariableCostsComponents/VariableCostTable.vue
+++ b/src/components/VariableCostsComponents/VariableCostTable.vue
@@ -8,6 +8,7 @@ import VariableCostDataInput from '../VariableCostsComponents/VariableCostDataIn
 import scrollToNewCost from '../../assets/utility_functions/scrollToNewCost'
 import OptionsMenu from '../ModalComponents/OptionsMenu.vue'
 import { useModalStore } from '../../stores/modalStore'
+import VariableCostRow from '../FormComponents/VariableCostRow.vue'
 
 const modalStore = useModalStore()
 const { optionsMenuIsOpen } = storeToRefs(modalStore)
@@ -48,7 +49,19 @@ onUpdated(() => {
         :id="variableCost.id"
         :key="variableCost.id"
       >
-        <div class="flex flex-row w-full items-end" @click="openEditFormModal(variableCost.id, 'variable')">
+      <variable-cost-row
+          @click="openEditFormModal(variableCost.id, 'variable')"
+          parentClass="flex flex-row w-full items-end"
+          cellClass="basis-6/18 pr-2 md:pr-6"
+          pClass="border-b border-grey-200"
+          :name="variableCost.id"
+          :costName="variableCost.name"
+          :category="variableCost.category"
+          :amount="variableCost.amount"
+        >
+      
+        </variable-cost-row>
+        <!-- <div class="flex flex-row w-full items-end" @click="openEditFormModal(variableCost.id, 'variable')">
           <div class="basis-6/18 pr-2 md:pr-6">
             <p class="border-b border-grey-200">{{ variableCost.name }}</p>
           </div>
@@ -58,7 +71,7 @@ onUpdated(() => {
           <div class="basis-6/18 pr-2 md:pr-6">
             <p class="border-b border-grey-200">$ {{ variableCost.amount }}</p>
           </div>
-        </div>
+        </div> -->
         <form-button
           class="md:flex md:flex-row hidden basis-3/24 h-full pt-6"
           btnImage="/src/images/delete-cost.svg"

--- a/src/components/VariableCostsComponents/VariableCostTable.vue
+++ b/src/components/VariableCostsComponents/VariableCostTable.vue
@@ -61,17 +61,6 @@ onUpdated(() => {
         >
       
         </variable-cost-row>
-        <!-- <div class="flex flex-row w-full items-end" @click="openEditFormModal(variableCost.id, 'variable')">
-          <div class="basis-6/18 pr-2 md:pr-6">
-            <p class="border-b border-grey-200">{{ variableCost.name }}</p>
-          </div>
-          <div class="basis-6/18 pr-2 md:pr-6">
-            <p class="border-b border-grey-200">{{ variableCost.category }}</p>
-          </div>
-          <div class="basis-6/18 pr-2 md:pr-6">
-            <p class="border-b border-grey-200">$ {{ variableCost.amount }}</p>
-          </div>
-        </div> -->
         <form-button
           class="md:flex md:flex-row hidden basis-3/24 h-full pt-6"
           btnImage="/src/images/delete-cost.svg"

--- a/src/stores/modalStore.ts
+++ b/src/stores/modalStore.ts
@@ -40,6 +40,7 @@ export const useModalStore = defineStore('modalStore', {
         const { addSelectedIdAction } = reportStore
         addSelectedIdAction(id)
         this.optionsMenuIsOpen = true
+        console.log("hello")
       } catch {
         console.error('error in openOptionsMenu')
       }

--- a/src/stores/reportStore.ts
+++ b/src/stores/reportStore.ts
@@ -193,7 +193,7 @@ export const useReportStore = defineStore('reportStore', {
     },
     deleteFixedCostAction() {
       const modalStore = useModalStore()
-      const { closeOptionsMenu, closeConfirmModal } = modalStore
+      const { closeOptionsMenu, closeConfirmModal, notify } = modalStore
 
       try {
         this.selectedCost = this.fixedCosts.find((item) => item.id === this.selectedId) as CostItem
@@ -206,11 +206,12 @@ export const useReportStore = defineStore('reportStore', {
       } finally {
         closeOptionsMenu()
         closeConfirmModal()
+        notify()
       }
     },
     deleteVariableCostAction() {
       const modalStore = useModalStore()
-      const { closeOptionsMenu, closeConfirmModal } = modalStore
+      const { closeOptionsMenu, closeConfirmModal, notify } = modalStore
 
       try {
         this.selectedCost = this.variableCosts.find(
@@ -225,6 +226,7 @@ export const useReportStore = defineStore('reportStore', {
       } finally {
         closeOptionsMenu()
         closeConfirmModal()
+        notify()
       }
     },
     addBookingsPerMonthAction(bookingsPerMonth: number) {


### PR DESCRIPTION
- added openEditFormModal to cost-row component in FixedCostTable
- added variable-cost-row component to match fixed-cost-row without the frequncy and individualtotal cells
- moved options menu to same div as fixed-cost-row (with the v-for, class=relative), set options-menu div to absolute top-0 right-0
- options menu works on the variable cost table as it does on the fixed cost table
- cleaned up, removed console.logs and comments, added notify() to deleteXCostActions to display the toast message
